### PR TITLE
fix: use correct error method in apiKeyAuth

### DIFF
--- a/internal/auth/apikeyAuth.go
+++ b/internal/auth/apikeyAuth.go
@@ -21,7 +21,7 @@ func ApiKeyAuth(c *gin.Context) {
 	ctx := c.Request.Context()
 	if len(apikey) == 0 {
 		rerr := rorerror.NewRorError(401, "api key not provided")
-		rerr.GinLogErrorAbort(c)
+		rerr.GinLogErrorAndAbort(c)
 		return
 	}
 
@@ -39,7 +39,7 @@ func ApiKeyAuth(c *gin.Context) {
 		serviceAuth(c, apikeyResult)
 	default:
 		rerr := rorerror.NewRorError(401, "error wrong api key type")
-		rerr.GinLogErrorAbort(c)
+		rerr.GinLogErrorAndAbort(c)
 	}
 
 }


### PR DESCRIPTION
IDE gave errors about these lines, assume they went unnoticed in the recent merges.