### PR TITLE
fix: dex trying to reach mocc via host system

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,8 @@ services:
         condition: service_started
       init-dex-db:
         condition: service_completed_successfully
+      mocc:
+        condition: service_started
     links:
       - openldap
     ports:
@@ -185,7 +187,5 @@ services:
       - PORT=6006
     volumes:
       - ${ROR_ASSETS_PATH:-./hacks/assets}/mocc/users.yaml:/config/users.yaml:ro
-    profiles:
-      - mocc
 volumes:
   data: {}

--- a/hacks/assets/dex/configs/dex-config-default.yaml
+++ b/hacks/assets/dex/configs/dex-config-default.yaml
@@ -88,7 +88,7 @@ connectors:
   id: mocc
   name: Mocc
   config:
-    issuer: http://host.docker.internal:6006
+    issuer: http://ror-dev-mocc:6006
     providerDiscoveryOverrides:
       AuthURL: http://localhost:6006/authorize
     clientID: ror.sky.test.nhn.no


### PR DESCRIPTION
Had some issues on Fedora with dex not reaching mocc. Saw that dex tried was configured to look for mocc on host.docker.internal. Changed it to use the docker internal dns name of mocc instead and it resolved the issue. Unless we need to go via the host we should go directly between the containers as much as possible.