### PR TITLE
chore/go-fix

### DIFF
--- a/internal/acl/repositories/aclV2Repository.go
+++ b/internal/acl/repositories/aclV2Repository.go
@@ -55,7 +55,7 @@ func (o ownerRefs) SubjectIsSet(scope aclmodels.Acl2Scope, subject aclmodels.Acl
 	return false
 }
 
-type mongoAggregateFunc func(ctx context.Context, col string, query []bson.M, value interface{}) error
+type mongoAggregateFunc func(ctx context.Context, col string, query []bson.M, value any) error
 
 var mongoAggregate mongoAggregateFunc = mongodb.Aggregate
 

--- a/internal/acl/repositories/aclV2Repository_test.go
+++ b/internal/acl/repositories/aclV2Repository_test.go
@@ -161,7 +161,7 @@ func Test_GetOwnerrefsQueryAcl2ByIdentityAccess(t *testing.T) {
 
 	t.Run("mongo error => deny all", func(t *testing.T) {
 		orig := mongoAggregate
-		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value interface{}) error {
+		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value any) error {
 			return errors.New("boom")
 		}
 		t.Cleanup(func() { mongoAggregate = orig })
@@ -175,7 +175,7 @@ func Test_GetOwnerrefsQueryAcl2ByIdentityAccess(t *testing.T) {
 
 	t.Run("mongo success => compiled match", func(t *testing.T) {
 		orig := mongoAggregate
-		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value interface{}) error {
+		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value any) error {
 			out, ok := value.(*[]aclmodels.AclV2ListItem)
 			if !ok {
 				return errors.New("unexpected output type")
@@ -219,7 +219,7 @@ func Test_CheckAcl2AccessByIdentityQueryAccess(t *testing.T) {
 
 	t.Run("user identity uses db results", func(t *testing.T) {
 		orig := mongoAggregate
-		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value interface{}) error {
+		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value any) error {
 			out, ok := value.(*[]aclmodels.AclV2ListItem)
 			if !ok {
 				return errors.New("unexpected output type")
@@ -326,7 +326,7 @@ func Test_GetAllACL2(t *testing.T) {
 	ctx := context.WithValue(context.Background(), identitymodels.ContexIdentity, identitymocks.IdentityUserValid)
 
 	t.Run("propagates mongo error", func(t *testing.T) {
-		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value interface{}) error {
+		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value any) error {
 			return errors.New("db down")
 		}
 		_, err := GetAllACL2(ctx)
@@ -336,7 +336,7 @@ func Test_GetAllACL2(t *testing.T) {
 	})
 
 	t.Run("returns results", func(t *testing.T) {
-		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value interface{}) error {
+		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value any) error {
 			out, ok := value.(*[]aclmodels.AclV2ListItem)
 			if !ok {
 				return errors.New("unexpected output type")
@@ -385,7 +385,7 @@ func Test_GetACL2ByIdentityQuery(t *testing.T) {
 
 	t.Run("user identity uses db and compiles global", func(t *testing.T) {
 		orig := mongoAggregate
-		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value interface{}) error {
+		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value any) error {
 			out, ok := value.(*[]aclmodels.AclV2ListItem)
 			if !ok {
 				return errors.New("unexpected output type")
@@ -411,7 +411,7 @@ func Test_GetACL2ByIdentityQuery(t *testing.T) {
 
 	t.Run("user identity mongo error => empty result", func(t *testing.T) {
 		orig := mongoAggregate
-		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value interface{}) error {
+		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value any) error {
 			return errors.New("boom")
 		}
 		t.Cleanup(func() { mongoAggregate = orig })
@@ -442,7 +442,7 @@ func Test_CheckAcl2ByIdentityQuery(t *testing.T) {
 		ctx := context.WithValue(context.Background(), identitymodels.ContexIdentity, identitymocks.IdentityClusterValid)
 		q := aclmodels.NewAclV2QueryAccessScopeSubject(aclmodels.Acl2ScopeCluster, aclmodels.Acl2Subject("other"))
 		orig := mongoAggregate
-		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value interface{}) error {
+		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value any) error {
 			out := value.(*[]aclmodels.AclV2ListItem)
 			*out = []aclmodels.AclV2ListItem{}
 			return nil
@@ -457,7 +457,7 @@ func Test_CheckAcl2ByIdentityQuery(t *testing.T) {
 
 	t.Run("user identity compiles access", func(t *testing.T) {
 		orig := mongoAggregate
-		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value interface{}) error {
+		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value any) error {
 			out, ok := value.(*[]aclmodels.AclV2ListItem)
 			if !ok {
 				return errors.New("unexpected output type")
@@ -477,7 +477,7 @@ func Test_CheckAcl2ByIdentityQuery(t *testing.T) {
 
 	t.Run("user identity mongo error => denyall", func(t *testing.T) {
 		orig := mongoAggregate
-		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value interface{}) error {
+		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value any) error {
 			return errors.New("boom")
 		}
 		t.Cleanup(func() { mongoAggregate = orig })
@@ -499,7 +499,7 @@ func Test_GetAcl2ByQuery(t *testing.T) {
 	q := aclmodels.NewAclV2QueryAccessScopeSubject(aclmodels.Acl2ScopeCluster, aclmodels.Acl2Subject("c1"))
 
 	t.Run("mongo error => empty", func(t *testing.T) {
-		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value interface{}) error {
+		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value any) error {
 			return errors.New("boom")
 		}
 		got := GetAcl2ByQuery(ctx, q)
@@ -509,7 +509,7 @@ func Test_GetAcl2ByQuery(t *testing.T) {
 	})
 
 	t.Run("mongo success => returns list", func(t *testing.T) {
-		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value interface{}) error {
+		mongoAggregate = func(ctx context.Context, col string, query []bson.M, value any) error {
 			out := value.(*[]aclmodels.AclV2ListItem)
 			*out = []aclmodels.AclV2ListItem{{Scope: aclmodels.Acl2ScopeCluster, Subject: aclmodels.Acl2Subject("c1")}}
 			return nil
@@ -523,7 +523,7 @@ func Test_GetAcl2ByQuery(t *testing.T) {
 
 func Test_CheckAcl2AccessByIdentityQueryAccess_ErrorFromDB(t *testing.T) {
 	orig := mongoAggregate
-	mongoAggregate = func(ctx context.Context, col string, query []bson.M, value interface{}) error {
+	mongoAggregate = func(ctx context.Context, col string, query []bson.M, value any) error {
 		return errors.New("boom")
 	}
 	t.Cleanup(func() { mongoAggregate = orig })

--- a/internal/apiservices/clustersservice/clustersservice.go
+++ b/internal/apiservices/clustersservice/clustersservice.go
@@ -208,20 +208,20 @@ func CpuMemPercentageCalc(cluster *apicontracts.Cluster) {
 	cluster.Topology.ControlPlane.Metrics.MemoryPercentage = services.MemoryPercentage(cluster.Topology.ControlPlane.Metrics.Memory, cluster.Topology.ControlPlane.Metrics.MemoryConsumed)
 	controlPlaneNodesLength := len(cluster.Topology.ControlPlane.Nodes)
 
-	for i := 0; i < controlPlaneNodesLength; i++ {
+	for i := range controlPlaneNodesLength {
 		node := cluster.Topology.ControlPlane.Nodes[i]
 		(&cluster.Topology.ControlPlane.Nodes[i]).Metrics.CpuPercentage = services.CpuPercentage(node.Metrics.Cpu, node.Metrics.CpuConsumed)
 		(&cluster.Topology.ControlPlane.Nodes[i]).Metrics.MemoryPercentage = services.MemoryPercentage(node.Metrics.Memory, node.Metrics.MemoryConsumed)
 	}
 
 	lengthNodePools := len(cluster.Topology.NodePools)
-	for j := 0; j < lengthNodePools; j++ {
+	for j := range lengthNodePools {
 		nodePool := cluster.Topology.NodePools[j]
 		(&cluster.Topology.NodePools[j]).Metrics.CpuPercentage = services.CpuPercentage(nodePool.Metrics.Cpu, nodePool.Metrics.CpuConsumed)
 		(&cluster.Topology.NodePools[j]).Metrics.MemoryPercentage = services.MemoryPercentage(nodePool.Metrics.Memory, nodePool.Metrics.MemoryConsumed)
 
 		lengthNodePoolNodes := len(nodePool.Nodes)
-		for k := 0; k < lengthNodePoolNodes; k++ {
+		for k := range lengthNodePoolNodes {
 			node := nodePool.Nodes[k]
 			(&nodePool.Nodes[k]).Metrics.CpuPercentage = services.CpuPercentage(node.Metrics.Cpu, node.Metrics.CpuConsumed)
 			(&nodePool.Nodes[k]).Metrics.MemoryPercentage = services.MemoryPercentage(node.Metrics.Memory, node.Metrics.MemoryConsumed)
@@ -268,12 +268,12 @@ func FindMachineClass(ctx context.Context, cluster *apicontracts.Cluster) {
 
 	var aggPrice int64
 	lengthNodePools := len(cluster.Topology.NodePools)
-	for j := 0; j < lengthNodePools; j++ {
+	for j := range lengthNodePools {
 		nodePool := cluster.Topology.NodePools[j]
 		lengthNodePoolNodes := len(nodePool.Nodes)
 		var nodePoolPrice int64
 		var machineClassName string
-		for k := 0; k < lengthNodePoolNodes; k++ {
+		for k := range lengthNodePoolNodes {
 			node := nodePool.Nodes[k]
 			var price int64
 			price, machineClassName = services.FindMachineClass(node.Metrics.Memory, node.Metrics.Cpu, provider, prices)

--- a/internal/apiservices/desiredversionservice/desiredversionservice.go
+++ b/internal/apiservices/desiredversionservice/desiredversionservice.go
@@ -20,7 +20,7 @@ func GetByKey(ctx context.Context, key string) (*apicontracts.DesiredVersion, er
 	return desiredversionrepo.GetByKey(ctx, key)
 }
 
-func GetByID(ctx context.Context, id interface{}) (*apicontracts.DesiredVersion, error) {
+func GetByID(ctx context.Context, id any) (*apicontracts.DesiredVersion, error) {
 	return desiredversionrepo.GetByID(ctx, id)
 }
 func GetAll(ctx context.Context) ([]apicontracts.DesiredVersion, error) {

--- a/internal/apiservices/math.go
+++ b/internal/apiservices/math.go
@@ -34,7 +34,7 @@ func FindMachineClass(memoryAllocatedBytes int64, cpuAllocated int64, provider p
 	}
 	memorygb := math.Round(float64(memoryAllocatedBytes) / float64(1050000000))
 	var price apicontracts.Price
-	for i := 0; i < pricesCount; i++ {
+	for i := range pricesCount {
 		p := prices[i]
 		if p.Cpu == int(cpuAllocated) && p.Memory == int64(memorygb) && p.Provider == provider {
 			price = p

--- a/internal/apiservices/resourcesService/resourceService.go
+++ b/internal/apiservices/resourcesService/resourceService.go
@@ -110,7 +110,7 @@ func ResourceDeleteService(ctx context.Context, resourceUpdate apiresourcecontra
 	if err := apiconnections.RabbitMQConnection.SendMessage(ctx,
 		resourceUpdate,
 		messagebuscontracts.Route_ResourceDeleted,
-		map[string]interface{}{"apiVersion": resourceUpdate.ApiVersion, "kind": resourceUpdate.Kind}); err != nil {
+		map[string]any{"apiVersion": resourceUpdate.ApiVersion, "kind": resourceUpdate.Kind}); err != nil {
 		return err
 	}
 
@@ -142,12 +142,12 @@ func sendToMessageBus(ctx context.Context, resource any, action apiresourcecontr
 		_ = apiconnections.RabbitMQConnection.SendMessage(ctx,
 			payload,
 			messagebuscontracts.Route_ResourceCreated,
-			map[string]interface{}{"apiVersion": payload.ApiVersion, "kind": payload.Kind})
+			map[string]any{"apiVersion": payload.ApiVersion, "kind": payload.Kind})
 	case apiresourcecontracts.K8sActionUpdate:
 		_ = apiconnections.RabbitMQConnection.SendMessage(ctx,
 			payload,
 			messagebuscontracts.Route_ResourceUpdated,
-			map[string]interface{}{"apiVersion": payload.ApiVersion, "kind": payload.Kind})
+			map[string]any{"apiVersion": payload.ApiVersion, "kind": payload.Kind})
 	}
 	return nil
 }

--- a/internal/apiservices/resourcesv2service/database.go
+++ b/internal/apiservices/resourcesv2service/database.go
@@ -149,7 +149,7 @@ func flattenBsonM(prefix string, doc bson.M, result bson.M) {
 
 // isZeroValue returns true for primitive zero values that should be skipped
 // during partial updates: empty strings, zero numbers, and false booleans.
-func isZeroValue(v interface{}) bool {
+func isZeroValue(v any) bool {
 	switch val := v.(type) {
 	case string:
 		return val == ""

--- a/internal/apiservices/resourcesv2service/database_test.go
+++ b/internal/apiservices/resourcesv2service/database_test.go
@@ -453,7 +453,7 @@ func TestSet_Idempotent(t *testing.T) {
 	resource := makePodResource("uid-idem", map[string]string{"app": "test"}, nil, "Running")
 
 	// Set the same resource 3 times — should always succeed with the same data
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		err := repo.Set(ctx, resource)
 		require.NoError(t, err, "Set should be idempotent (attempt %d)", i+1)
 	}
@@ -561,7 +561,7 @@ func TestSet_LargeLabelsCount(t *testing.T) {
 	ctx := testCtx()
 
 	labels := make(map[string]string, 50)
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		labels[fmt.Sprintf("label-%d", i)] = fmt.Sprintf("value-%d", i)
 	}
 
@@ -719,7 +719,7 @@ func TestGet_MultipleUIDs(t *testing.T) {
 	repo := newTestRepo(t)
 	ctx := testCtx()
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		r := makePodResource(fmt.Sprintf("uid-multi-%d", i), nil, nil, "Running")
 		r.Metadata.Name = fmt.Sprintf("pod-%d", i)
 		require.NoError(t, repo.Set(ctx, r))
@@ -805,7 +805,7 @@ func TestGet_WithPagination(t *testing.T) {
 	repo := newTestRepo(t)
 	ctx := testCtx()
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		r := makePodResource(fmt.Sprintf("uid-page-%02d", i), nil, nil, "Running")
 		r.Metadata.Name = fmt.Sprintf("pod-%02d", i)
 		require.NoError(t, repo.Set(ctx, r))
@@ -1005,7 +1005,7 @@ func TestFlattenBsonM_BsonDWithDottedKeys(t *testing.T) {
 func TestIsZeroValue(t *testing.T) {
 	tests := []struct {
 		name   string
-		value  interface{}
+		value  any
 		isZero bool
 	}{
 		{"empty string", "", true},

--- a/internal/apiservices/resourcesv2service/resourcesv2service.go
+++ b/internal/apiservices/resourcesv2service/resourcesv2service.go
@@ -503,17 +503,17 @@ func sendToMessageBus(ctx context.Context, resource *rorresources.Resource, acti
 		_ = apiconnections.RabbitMQConnection.SendMessage(ctx,
 			payload,
 			messagebuscontracts.Route_ResourceCreated,
-			map[string]interface{}{"apiVersion": payload.ApiVersion, "kind": payload.Kind})
+			map[string]any{"apiVersion": payload.ApiVersion, "kind": payload.Kind})
 	case rortypes.K8sActionUpdate:
 		_ = apiconnections.RabbitMQConnection.SendMessage(ctx,
 			payload,
 			messagebuscontracts.Route_ResourceUpdated,
-			map[string]interface{}{"apiVersion": payload.ApiVersion, "kind": payload.Kind})
+			map[string]any{"apiVersion": payload.ApiVersion, "kind": payload.Kind})
 	case rortypes.K8sActionDelete:
 		_ = apiconnections.RabbitMQConnection.SendMessage(ctx,
 			payload,
 			messagebuscontracts.Route_ResourceDeleted,
-			map[string]interface{}{"apiVersion": payload.ApiVersion, "kind": payload.Kind})
+			map[string]any{"apiVersion": payload.ApiVersion, "kind": payload.Kind})
 	}
 	return nil
 }

--- a/internal/clients/gitlab/helsegitlab.go
+++ b/internal/clients/gitlab/helsegitlab.go
@@ -75,7 +75,7 @@ func getGitlabClient(vaultClient *vaultclient.VaultClient) (*http.Client, string
 		return nil, "", errors.New("could not extract gitlab access token from vault")
 	}
 
-	commonConfig, ok := vaultData["data"].(map[string]interface{})
+	commonConfig, ok := vaultData["data"].(map[string]any)
 	if !ok {
 		rlog.Error("", fmt.Errorf("data type assertion failed: %T %#v", vaultData["data"], vaultData["data"]))
 		return nil, "", errors.New("could not extract gitlab access token from vault-data")

--- a/internal/controllers/clusterscontroller/clusters_controller.go
+++ b/internal/controllers/clusterscontroller/clusters_controller.go
@@ -79,7 +79,7 @@ func ClusterGetById() gin.HandlerFunc {
 		var _ apicontracts.Cluster
 		cluster, err := clustersservice.GetByClusterId(ctx, clusterId)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, map[string]interface{}{"success": false, "message": "error when fetching data centers"})
+			c.JSON(http.StatusInternalServerError, map[string]any{"success": false, "message": "error when fetching data centers"})
 			return
 		}
 
@@ -124,11 +124,11 @@ func ClusterExistsById() gin.HandlerFunc {
 
 		exists, err := clustersservice.Exists(ctx, clusterId)
 		if err != nil {
-			c.JSON(http.StatusOK, map[string]interface{}{"exists": false})
+			c.JSON(http.StatusOK, map[string]any{"exists": false})
 			return
 		}
 
-		c.JSON(http.StatusOK, map[string]interface{}{"exists": exists})
+		c.JSON(http.StatusOK, map[string]any{"exists": exists})
 	}
 }
 
@@ -371,7 +371,7 @@ func UpdateMetadata() gin.HandlerFunc {
 
 		err = clustersservice.UpdateMetadata(ctx, &input, clusters.Data[0])
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, map[string]interface{}{"status": false, "message": "could not update cluster metadata"})
+			c.JSON(http.StatusInternalServerError, map[string]any{"status": false, "message": "could not update cluster metadata"})
 			return
 		}
 
@@ -411,14 +411,14 @@ func RegisterHeartbeat() gin.HandlerFunc {
 		//TODO: return rorerror.RorError
 		//validate the request body
 		if err := c.BindJSON(&input); err != nil {
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 
 		//TODO: return rorerror.RorError
 		//use the validator library to validate required fields
 		if validationErr := validate.Struct(&input); validationErr != nil {
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": validationErr.Error()}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": validationErr.Error()}})
 			return
 		}
 		// Access check
@@ -437,7 +437,7 @@ func RegisterHeartbeat() gin.HandlerFunc {
 		defer span1.End()
 		err := clustersservice.CreateOrUpdate(ctx, &input, input.ClusterId)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 		span1.End()

--- a/internal/controllers/clusterscontroller/clusterviews.go
+++ b/internal/controllers/clusterscontroller/clusterviews.go
@@ -92,7 +92,7 @@ func PolicyreportsView() gin.HandlerFunc {
 
 		policyreport, err := clustersservice.GetViewPolicyreport(ctx, ownerref)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 
@@ -147,7 +147,7 @@ func PolicyreportSummaryView() gin.HandlerFunc {
 		policyreport, err := clustersservice.GetViewPolicyReportSummary(ctx, query, clusterID)
 
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 
@@ -200,7 +200,7 @@ func VulnerabilityreportSummaryView() gin.HandlerFunc {
 
 		policyreport, err := clustersservice.GetViewPolicyReportSummary(ctx, query, clusterID)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 
@@ -249,7 +249,7 @@ func VulnerabilityReportsView() gin.HandlerFunc {
 
 		vulnerabilityreports, err := clustersservice.GetViewVulnerabilityReports(ctx, ownerref)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 
@@ -298,7 +298,7 @@ func VulnerabilityReportsViewById() gin.HandlerFunc {
 
 		vulnerabilityreports, err := clustersservice.GetViewVulnerabilityReportsById(ctx, cveId)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 
@@ -339,7 +339,7 @@ func VulnerabilityReportsGlobal() gin.HandlerFunc {
 		vulnerabilityreports, err := clustersservice.GetViewVulnerabilityReportsGlobal(ctx)
 		if err != nil {
 			rlog.Error("error while fetching global vulnerability reports: %w", err)
-			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 
@@ -388,7 +388,7 @@ func GlobalVulnerabilityReportsViewById() gin.HandlerFunc {
 		vulnerabilityreports, err := clustersservice.GetGlobalViewVulnerabilityReportsById(ctx, cveId)
 		if err != nil {
 			rlog.Errorc(ctx, "Error while getting global vulnerabilityreportview by CVE ID", err)
-			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 
@@ -478,7 +478,7 @@ func ComplianceReportsGlobal() gin.HandlerFunc {
 		complianceReports, err := clustersservice.GetClusterComplianceReportsGlobal(ctx)
 		if err != nil {
 			rlog.Error("error while fetching global vulnerability reports: %w", err)
-			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 

--- a/internal/controllers/desiredversioncontroller/desired_version_controller_test.go
+++ b/internal/controllers/desiredversioncontroller/desired_version_controller_test.go
@@ -29,13 +29,13 @@ func MockCreateOne() gin.HandlerFunc {
 		var input apicontracts.DesiredVersion
 
 		if err := c.BindJSON(&input); err != nil {
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 
 		for _, v := range mockData {
 			if v.Key == input.Key {
-				c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": fmt.Sprintf("Desired version with key: %s already exists.", input.Key)}})
+				c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": fmt.Sprintf("Desired version with key: %s already exists.", input.Key)}})
 				return
 			}
 		}

--- a/internal/controllers/metricscontroller/metrics_controller.go
+++ b/internal/controllers/metricscontroller/metrics_controller.go
@@ -118,13 +118,13 @@ func RegisterResourceMetricsReport() gin.HandlerFunc {
 
 		//validate the request body
 		if err := c.BindJSON(&input); err != nil {
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 
 		//use the validator library to validate required fields
 		if validationErr := validate.Struct(&input); validationErr != nil {
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": validationErr.Error()}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": validationErr.Error()}})
 			return
 		}
 		ownerref := apiresourcecontracts.ResourceOwnerReference{
@@ -139,7 +139,7 @@ func RegisterResourceMetricsReport() gin.HandlerFunc {
 
 		err := metricsservice.ProcessMetricReport(ctx, &input)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 

--- a/internal/controllers/resourcescontroller/resources_controller.go
+++ b/internal/controllers/resourcescontroller/resources_controller.go
@@ -125,7 +125,7 @@ func GetResourceHashList() gin.HandlerFunc {
 		hashList, err := resourcesservice.ResourceGetHashlist(ctx, resourceOwner)
 		if err != nil {
 			rlog.Error("Error getting resource hash list:", err)
-			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 

--- a/internal/controllers/resourcescontroller/resources_controller_create.go
+++ b/internal/controllers/resourcescontroller/resources_controller_create.go
@@ -47,12 +47,12 @@ func NewResource() gin.HandlerFunc {
 
 		//validate the request body
 		if err := c.BindJSON(&input); err != nil {
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 		//use the validator library to validate required fields
 		if validationErr := validate.Struct(&input); validationErr != nil {
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": validationErr.Error()}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": validationErr.Error()}})
 			return
 		}
 
@@ -64,7 +64,7 @@ func NewResource() gin.HandlerFunc {
 		subject := input.Owner.Subject
 
 		if subject == "" || scope == "" {
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": "owner scope and subject must be set"}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": "owner scope and subject must be set"}})
 			return
 		}
 
@@ -86,7 +86,7 @@ func NewResource() gin.HandlerFunc {
 
 		err := resourcesservice.ResourceNewCreateService(ctx, input)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 

--- a/internal/controllers/resourcescontroller/resources_controller_delete.go
+++ b/internal/controllers/resourcescontroller/resources_controller_delete.go
@@ -47,12 +47,12 @@ func DeleteResource() gin.HandlerFunc {
 		if hasBody {
 			//validate the request body
 			if err := c.BindJSON(&input); err != nil {
-				c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			//use the validator library to validate required fields
 			if validationErr := validate.Struct(&input); validationErr != nil {
-				c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": validationErr.Error()}})
+				c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": validationErr.Error()}})
 				return
 			}
 
@@ -66,7 +66,7 @@ func DeleteResource() gin.HandlerFunc {
 			subject := input.Owner.Subject
 
 			if subject == "" || scope == "" {
-				c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": "owner scope and subject must be set"}})
+				c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": "owner scope and subject must be set"}})
 				return
 			}
 
@@ -83,7 +83,7 @@ func DeleteResource() gin.HandlerFunc {
 
 			err := resourcesservice.ResourceDeleteService(ctx, input)
 			if err != nil {
-				c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 
@@ -92,17 +92,17 @@ func DeleteResource() gin.HandlerFunc {
 		} else {
 			uid := c.Param("uid")
 			if uid == "" {
-				c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": "uid must be set"}})
+				c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": "uid must be set"}})
 				return
 			}
 			resourcemeta, err := resourcesservice.GetResourceMetadataByUid(ctx, uid)
 			if err != nil {
-				c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 
 			if resourcemeta.Uid == "" {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": "resource not found"}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": "resource not found"}})
 				return
 			}
 
@@ -110,7 +110,7 @@ func DeleteResource() gin.HandlerFunc {
 			subject := resourcemeta.Owner.Subject
 
 			if subject == "" || scope == "" {
-				c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": "owner scope and subject must be set"}})
+				c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": "owner scope and subject must be set"}})
 				return
 			}
 
@@ -135,7 +135,7 @@ func DeleteResource() gin.HandlerFunc {
 				Resource:   nil, // Resource is not needed for delete
 			})
 			if err != nil {
-				c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 

--- a/internal/controllers/resourcescontroller/resources_controller_read_generated.go
+++ b/internal/controllers/resourcescontroller/resources_controller_read_generated.go
@@ -51,7 +51,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "v1" && query.Kind == "Namespace" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceNamespace](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -59,7 +59,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "v1" && query.Kind == "Node" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceNode](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -67,7 +67,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "v1" && query.Kind == "PersistentVolumeClaim" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourcePersistentVolumeClaim](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -75,7 +75,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "apps/v1" && query.Kind == "Deployment" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceDeployment](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -83,7 +83,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "storage.k8s.io/v1" && query.Kind == "StorageClass" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceStorageClass](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -91,7 +91,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "wgpolicyk8s.io/v1alpha2" && query.Kind == "PolicyReport" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourcePolicyReport](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -99,7 +99,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "argoproj.io/v1alpha1" && query.Kind == "Application" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceApplication](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -107,7 +107,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "argoproj.io/v1alpha1" && query.Kind == "AppProject" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceAppProject](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -115,7 +115,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "cert-manager.io/v1" && query.Kind == "Certificate" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceCertificate](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -123,7 +123,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "v1" && query.Kind == "Service" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceService](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -131,7 +131,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "v1" && query.Kind == "Pod" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourcePod](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -139,7 +139,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "apps/v1" && query.Kind == "ReplicaSet" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceReplicaSet](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -147,7 +147,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "apps/v1" && query.Kind == "StatefulSet" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceStatefulSet](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -155,7 +155,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "apps/v1" && query.Kind == "DaemonSet" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceDaemonSet](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -163,7 +163,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "networking.k8s.io/v1" && query.Kind == "Ingress" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceIngress](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -171,7 +171,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "networking.k8s.io/v1" && query.Kind == "IngressClass" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceIngressClass](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -179,7 +179,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "aquasecurity.github.io/v1alpha1" && query.Kind == "VulnerabilityReport" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceVulnerabilityReport](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -187,7 +187,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "aquasecurity.github.io/v1alpha1" && query.Kind == "ExposedSecretReport" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceExposedSecretReport](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -195,7 +195,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "aquasecurity.github.io/v1alpha1" && query.Kind == "ConfigAuditReport" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceConfigAuditReport](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -203,7 +203,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "aquasecurity.github.io/v1alpha1" && query.Kind == "RbacAssessmentReport" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceRbacAssessmentReport](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -211,7 +211,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "run.tanzu.vmware.com/v1alpha3" && query.Kind == "TanzuKubernetesCluster" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceTanzuKubernetesCluster](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -219,7 +219,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "run.tanzu.vmware.com/v1alpha3" && query.Kind == "TanzuKubernetesRelease" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceTanzuKubernetesRelease](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -227,7 +227,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "vmoperator.vmware.com/v1alpha2" && query.Kind == "VirtualMachineClass" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceVirtualMachineClass](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -235,7 +235,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "KubernetesCluster" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceKubernetesCluster](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -243,7 +243,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "ClusterOrder" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceClusterOrder](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -251,7 +251,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "Project" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceProject](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -259,7 +259,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "Configuration" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceConfiguration](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -267,7 +267,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "aquasecurity.github.io/v1alpha1" && query.Kind == "ClusterComplianceReport" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceClusterComplianceReport](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -275,7 +275,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "ClusterVulnerabilityReport" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceClusterVulnerabilityReport](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -283,7 +283,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "Route" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceRoute](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -291,7 +291,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "SlackMessage" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceSlackMessage](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -299,7 +299,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "VulnerabilityEvent" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceVulnerabilityEvent](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -307,7 +307,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "VirtualMachine" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceVirtualMachine](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -315,7 +315,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "v1" && query.Kind == "Endpoints" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceEndpoints](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -323,7 +323,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "networking.k8s.io/v1" && query.Kind == "NetworkPolicy" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.ResourceNetworkPolicy](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -379,7 +379,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "v1" && query.Kind == "Namespace" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceNamespace](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -387,7 +387,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "v1" && query.Kind == "Node" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceNode](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -395,7 +395,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "v1" && query.Kind == "PersistentVolumeClaim" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourcePersistentVolumeClaim](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -403,7 +403,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "apps/v1" && query.Kind == "Deployment" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceDeployment](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -411,7 +411,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "storage.k8s.io/v1" && query.Kind == "StorageClass" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceStorageClass](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -419,7 +419,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "wgpolicyk8s.io/v1alpha2" && query.Kind == "PolicyReport" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourcePolicyReport](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -427,7 +427,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "argoproj.io/v1alpha1" && query.Kind == "Application" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceApplication](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -435,7 +435,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "argoproj.io/v1alpha1" && query.Kind == "AppProject" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceAppProject](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -443,7 +443,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "cert-manager.io/v1" && query.Kind == "Certificate" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceCertificate](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -451,7 +451,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "v1" && query.Kind == "Service" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceService](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -459,7 +459,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "v1" && query.Kind == "Pod" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourcePod](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -467,7 +467,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "apps/v1" && query.Kind == "ReplicaSet" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceReplicaSet](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -475,7 +475,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "apps/v1" && query.Kind == "StatefulSet" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceStatefulSet](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -483,7 +483,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "apps/v1" && query.Kind == "DaemonSet" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceDaemonSet](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -491,7 +491,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "networking.k8s.io/v1" && query.Kind == "Ingress" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceIngress](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -499,7 +499,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "networking.k8s.io/v1" && query.Kind == "IngressClass" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceIngressClass](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -507,7 +507,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "aquasecurity.github.io/v1alpha1" && query.Kind == "VulnerabilityReport" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceVulnerabilityReport](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -515,7 +515,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "aquasecurity.github.io/v1alpha1" && query.Kind == "ExposedSecretReport" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceExposedSecretReport](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -523,7 +523,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "aquasecurity.github.io/v1alpha1" && query.Kind == "ConfigAuditReport" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceConfigAuditReport](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -531,7 +531,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "aquasecurity.github.io/v1alpha1" && query.Kind == "RbacAssessmentReport" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceRbacAssessmentReport](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -539,7 +539,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "run.tanzu.vmware.com/v1alpha3" && query.Kind == "TanzuKubernetesCluster" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceTanzuKubernetesCluster](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -547,7 +547,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "run.tanzu.vmware.com/v1alpha3" && query.Kind == "TanzuKubernetesRelease" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceTanzuKubernetesRelease](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -555,7 +555,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "vmoperator.vmware.com/v1alpha2" && query.Kind == "VirtualMachineClass" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceVirtualMachineClass](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -563,7 +563,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "KubernetesCluster" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceKubernetesCluster](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -571,7 +571,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "ClusterOrder" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceClusterOrder](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -579,7 +579,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "Project" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceProject](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -587,7 +587,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "Configuration" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceConfiguration](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -595,7 +595,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "aquasecurity.github.io/v1alpha1" && query.Kind == "ClusterComplianceReport" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceClusterComplianceReport](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -603,7 +603,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "ClusterVulnerabilityReport" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceClusterVulnerabilityReport](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -611,7 +611,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "Route" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceRoute](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -619,7 +619,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "SlackMessage" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceSlackMessage](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -627,7 +627,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "VulnerabilityEvent" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceVulnerabilityEvent](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -635,7 +635,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "general.ror.internal/v1alpha1" && query.Kind == "VirtualMachine" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceVirtualMachine](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -643,7 +643,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "v1" && query.Kind == "Endpoints" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceEndpoints](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -651,7 +651,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "networking.k8s.io/v1" && query.Kind == "NetworkPolicy" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.ResourceNetworkPolicy](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)

--- a/internal/controllers/resourcescontroller/resources_controller_read_generated.go.tmpl
+++ b/internal/controllers/resourcescontroller/resources_controller_read_generated.go.tmpl
@@ -53,7 +53,7 @@ func GetResources() gin.HandlerFunc {
 		if query.ApiVersion == "{{.GetApiVersion}}" && query.Kind == "{{.Kind}}" {
 			resources, err := resourcesservice.GetResources[apiresourcecontracts.Resource{{.Kind}}](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)
@@ -111,7 +111,7 @@ func GetResource() gin.HandlerFunc {
 		if query.ApiVersion == "{{.GetApiVersion}}" && query.Kind == "{{.Kind}}" {
 			resources, err := resourcesservice.GetResource[apiresourcecontracts.Resource{{.Kind}}](ctx, query)
 			if err != nil {
-				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+				c.JSON(http.StatusNotFound, responses.Cluster{Status: http.StatusNotFound, Message: "error", Data: map[string]any{"data": err.Error()}})
 				return
 			}
 			c.JSON(http.StatusOK, resources)

--- a/internal/controllers/resourcescontroller/resources_controller_update.go
+++ b/internal/controllers/resourcescontroller/resources_controller_update.go
@@ -47,12 +47,12 @@ func UpdateResource() gin.HandlerFunc {
 
 		//validate the request body
 		if err := c.BindJSON(&input); err != nil {
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 		//use the validator library to validate required fields
 		if validationErr := validate.Struct(&input); validationErr != nil {
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": validationErr.Error()}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": validationErr.Error()}})
 			return
 		}
 
@@ -71,7 +71,7 @@ func UpdateResource() gin.HandlerFunc {
 		subject := input.Owner.Subject
 
 		if subject == "" || scope == "" {
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": "owner scope and subject must be set"}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": "owner scope and subject must be set"}})
 			return
 		}
 		// Access check
@@ -92,7 +92,7 @@ func UpdateResource() gin.HandlerFunc {
 
 		err := resourcesservice.ResourceNewCreateService(ctx, input)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 

--- a/internal/controllers/v2/resourcescontroller/resources_controller.go
+++ b/internal/controllers/v2/resourcescontroller/resources_controller.go
@@ -165,7 +165,7 @@ func GetResourceHashList() gin.HandlerFunc {
 		if err != nil {
 			rortracer.SpanError(span, err, "failed to get hash list")
 			rlog.Error("Error getting resource hash list:", err)
-			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 

--- a/internal/controllers/v2/resourcescontroller/resources_controller_create.go
+++ b/internal/controllers/v2/resourcescontroller/resources_controller_create.go
@@ -1,6 +1,7 @@
 package resourcescontroller
 
 import (
+	"maps"
 	"net/http"
 
 	"github.com/NorskHelsenett/ror-api/internal/apiservices/resourcesv2service"
@@ -57,13 +58,13 @@ func NewResource() gin.HandlerFunc {
 		if err := c.BindJSON(&input); err != nil {
 			rortracer.SpanError(span, err, "failed to bind JSON")
 			rlog.Error("error binding json", err)
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 		//use the validator library to validate required fields
 		if validationErr := validate.Struct(&input); validationErr != nil {
 			rortracer.SpanError(span, validationErr, "validation failed")
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": validationErr.Error()}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": validationErr.Error()}})
 			return
 		}
 		span.AddEvent("request validated")
@@ -85,9 +86,7 @@ func NewResource() gin.HandlerFunc {
 
 		for i := 0; i < len(rs.Resources); i++ {
 			result := <-returnChannel
-			for key, result := range result.Results {
-				returnArray.Results[key] = result
-			}
+			maps.Copy(returnArray.Results, result.Results)
 		}
 		span.AddEvent("processing complete")
 

--- a/internal/controllers/v2/resourcescontroller/resources_controller_delete.go
+++ b/internal/controllers/v2/resourcescontroller/resources_controller_delete.go
@@ -87,7 +87,7 @@ func DeleteResource() gin.HandlerFunc {
 				responses.Cluster{
 					Status:  http.StatusInternalServerError,
 					Message: "error",
-					Data:    map[string]interface{}{"data": err.Error()},
+					Data:    map[string]any{"data": err.Error()},
 				})
 			return
 		}

--- a/internal/controllers/v2/resourcescontroller/resources_controller_patch.go
+++ b/internal/controllers/v2/resourcescontroller/resources_controller_patch.go
@@ -49,7 +49,7 @@ func PatchResource() gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, responses.Cluster{
 				Status:  http.StatusBadRequest,
 				Message: "error",
-				Data:    map[string]interface{}{"data": "uid is required"},
+				Data:    map[string]any{"data": "uid is required"},
 			})
 			return
 		}
@@ -60,7 +60,7 @@ func PatchResource() gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, responses.Cluster{
 				Status:  http.StatusBadRequest,
 				Message: "error",
-				Data:    map[string]interface{}{"data": err.Error()},
+				Data:    map[string]any{"data": err.Error()},
 			})
 			return
 		}

--- a/internal/controllers/v2/resourcescontroller/resources_controller_update.go
+++ b/internal/controllers/v2/resourcescontroller/resources_controller_update.go
@@ -47,13 +47,13 @@ func UpdateResource() gin.HandlerFunc {
 		//validate the request body
 		if err := c.BindJSON(&input); err != nil {
 			rortracer.SpanError(span, err, "failed to bind JSON")
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 		//use the validator library to validate required fields
 		if validationErr := validate.Struct(&input); validationErr != nil {
 			rortracer.SpanError(span, validationErr, "validation failed")
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": validationErr.Error()}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": validationErr.Error()}})
 			return
 		}
 
@@ -70,7 +70,7 @@ func UpdateResource() gin.HandlerFunc {
 
 		if subject == "" || scope == "" {
 			rortracer.SpanErrorf(span, "missing owner scope or subject")
-			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]interface{}{"data": "owner scope and subject must be set"}})
+			c.JSON(http.StatusBadRequest, responses.Cluster{Status: http.StatusBadRequest, Message: "error", Data: map[string]any{"data": "owner scope and subject must be set"}})
 			return
 		}
 		// Access check
@@ -89,7 +89,7 @@ func UpdateResource() gin.HandlerFunc {
 		err := resourcesservice.ResourceNewCreateService(ctx, input)
 		if err != nil {
 			rortracer.SpanError(span, err, "service failed")
-			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]interface{}{"data": err.Error()}})
+			c.JSON(http.StatusInternalServerError, responses.Cluster{Status: http.StatusInternalServerError, Message: "error", Data: map[string]any{"data": err.Error()}})
 			return
 		}
 

--- a/internal/databases/mongodb/mongoTypes/mongo_types.go
+++ b/internal/databases/mongodb/mongoTypes/mongo_types.go
@@ -46,10 +46,10 @@ type MongoCluster struct {
 	Topology      MongoTopology          `json:"topology"`
 	Versions      MongoVersions          `json:"versions"`
 	Ingresses     []MongoIngress         `json:"ingresses"`
-	Updated       time.Time              `json:"updated,omitempty"`
-	Created       time.Time              `json:"created,omitempty"`
-	LastObserved  time.Time              `json:"lastObserved,omitempty"`
-	FirstObserved time.Time              `json:"firstObserved,omitempty"`
+	Updated       time.Time              `json:"updated"`
+	Created       time.Time              `json:"created"`
+	LastObserved  time.Time              `json:"lastObserved"`
+	FirstObserved time.Time              `json:"firstObserved"`
 	HealthStatus  MongoHealthStatus      `json:"healthStatus"`
 	CreatedBy     string                 `json:"createdBy"`
 	SplunkIndex   string                 `json:"splunkIndex"`
@@ -89,8 +89,8 @@ type ClusterMetadata struct {
 }
 
 type MongoClusterConfig struct {
-	Versions  map[string]interface{} `json:"versions"`
-	Overrides map[string]interface{} `json:"overrides"`
+	Versions  map[string]any `json:"versions"`
+	Overrides map[string]any `json:"overrides"`
 }
 
 type MongoClusterWithWorkspace struct {

--- a/internal/databases/mongodb/repositories/desiredversion/desiredversion_repository.go
+++ b/internal/databases/mongodb/repositories/desiredversion/desiredversion_repository.go
@@ -49,7 +49,7 @@ func GetByKey(ctx context.Context, key string) (*apicontracts.DesiredVersion, er
 	return &result, nil
 }
 
-func GetByID(ctx context.Context, id interface{}) (*apicontracts.DesiredVersion, error) {
+func GetByID(ctx context.Context, id any) (*apicontracts.DesiredVersion, error) {
 	db := mongodb.GetMongoDb()
 	query := bson.M{"_id": id}
 	var result apicontracts.DesiredVersion

--- a/internal/databases/mongodb/repositories/metrics/metricsResource_repo.go
+++ b/internal/databases/mongodb/repositories/metrics/metricsResource_repo.go
@@ -22,7 +22,7 @@ const (
 
 func WriteMetrics(metricsreport *apicontracts.MetricsReport, clusterId string, ctx context.Context) {
 	db := mongodb.GetMongoDb()
-	queries := make([]interface{}, 0)
+	queries := make([]any, 0)
 
 	for _, metricUpdate := range metricsreport.Nodes {
 		query := bson.M{

--- a/internal/databases/mongodb/repositories/metrics/metrics_repository.go
+++ b/internal/databases/mongodb/repositories/metrics/metrics_repository.go
@@ -393,7 +393,7 @@ func GetForWorkspaces(ctx context.Context, filter *apicontracts.Filter) (*apicon
 		return nil, errors.New("Could not get metrics for workspaces")
 	}
 
-	for i := 0; i < lengthAgg; i++ {
+	for i := range lengthAgg {
 		data := agg[i]
 		metric := GetMetricItemFromPrimitivM(data)
 		metric.Id = fmt.Sprint(data["_id"])
@@ -514,7 +514,7 @@ func GetForWorkspacesByDatacenterId(ctx context.Context, filter *apicontracts.Fi
 		return nil, errors.New("Could not get metrics for workspaces by datacenter")
 	}
 
-	for i := 0; i < lengthAgg; i++ {
+	for i := range lengthAgg {
 		data := agg[i]
 		metric := GetMetricItemFromPrimitivM(data)
 		metric.Id = fmt.Sprint(data["_id"])

--- a/internal/helpers/mapping/mapping_helper.go
+++ b/internal/helpers/mapping/mapping_helper.go
@@ -16,13 +16,13 @@ func Map[F any, D any](from F, destination *D) error {
 	}
 
 	if err := json.Unmarshal(jsonByte, &destination); err != nil {
-		return fmt.Errorf("could not convert from json to %s: %v", reflect.TypeOf(destination), err)
+		return fmt.Errorf("could not convert from json to %s: %v", reflect.TypeFor[*D](), err)
 	}
 
 	return nil
 }
 
-func InterfaceToInt64(i interface{}) (int64, error) {
+func InterfaceToInt64(i any) (int64, error) {
 	switch v := i.(type) {
 	case int64:
 		return v, nil

--- a/internal/models/responses/cluster.go
+++ b/internal/models/responses/cluster.go
@@ -1,7 +1,7 @@
 package responses
 
 type Cluster struct {
-	Status  int                    `json:"status"`
-	Message string                 `json:"message"`
-	Data    map[string]interface{} `json:"data"`
+	Status  int            `json:"status"`
+	Message string         `json:"message"`
+	Data    map[string]any `json:"data"`
 }

--- a/internal/models/ssemodels/sse_models.go
+++ b/internal/models/ssemodels/sse_models.go
@@ -20,7 +20,7 @@ type Time struct {
 }
 
 type SseMessage struct {
-	Id    string      `json:"id omitempty"`
-	Event SseType     `json:"event"`
-	Data  interface{} `json:"data"`
+	Id    string  `json:"id omitempty"`
+	Event SseType `json:"event"`
+	Data  any     `json:"data"`
 }

--- a/internal/models/viewsmodels/vulnerabilityreports.go
+++ b/internal/models/viewsmodels/vulnerabilityreports.go
@@ -10,7 +10,7 @@ type VulnerabilityReportsView struct {
 	ClusterId                              string                              `json:"clusterId,omitempty"`
 	Namespaces                             []VulnerabilityReportsViewNamespace `json:"namespaces,omitempty"`
 	Environment                            string                              `json:"environment,omitempty"`
-	Project                                apicontracts.Project                `json:"project,omitempty"`
+	Project                                apicontracts.Project                `json:"project"`
 	apiresourcecontracts.AquaReportSummary `bson:"inline"`
 }
 type VulnerabilityReportsViewNamespace struct {
@@ -22,9 +22,9 @@ type VulnerabilityReportsViewNamespace struct {
 type VulnerabilityReportsViewReport struct {
 	Uid             string                                                                `json:"uid,omitempty"`
 	Name            string                                                                `json:"name,omitempty"`
-	OwnerRef        apiresourcecontracts.ResourceMetadataOwnerReference                   `json:"owner_ref,omitempty"`
-	Scanner         VulnerabilityReportsScanner                                           `json:"scanner,omitempty"`
-	Artifact        VulnerabilityReportsArtifact                                          `json:"artifact,omitempty"`
+	OwnerRef        apiresourcecontracts.ResourceMetadataOwnerReference                   `json:"owner_ref"`
+	Scanner         VulnerabilityReportsScanner                                           `json:"scanner"`
+	Artifact        VulnerabilityReportsArtifact                                          `json:"artifact"`
 	UpdateTimestamp string                                                                `json:"updateTimestamp"`
 	Vulnerabilities []apiresourcecontracts.ResourceVulnerabilityReportReportVulnerability `json:"vulnerabilities,omitempty"`
 	apiresourcecontracts.AquaReportSummary

--- a/internal/webserver/sse/sse.go
+++ b/internal/webserver/sse/sse.go
@@ -274,7 +274,7 @@ func KeepAlive() {
 
 func SendWelcomeMessage(client apicontracts.SSEClient) {
 	go func() {
-		payload := map[string]interface{}{
+		payload := map[string]any{
 			"message": "Welcome to ROR",
 		}
 		jsonData, err := json.Marshal(payload)

--- a/pkg/middelware/ssemiddleware/middleware.go
+++ b/pkg/middelware/ssemiddleware/middleware.go
@@ -27,8 +27,8 @@ func SSEHeadersMiddlewareV1() gin.HandlerFunc {
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "OPTIONS, GET")
 		requestOrigin := c.Request.Header.Get("Origin")
 		allowOrigins := rorconfig.GetString(rorconfig.HTTP_ALLOW_ORIGINS)
-		origins := strings.Split(allowOrigins, ";")
-		for _, origin := range origins {
+		origins := strings.SplitSeq(allowOrigins, ";")
+		for origin := range origins {
 			if strings.Contains(requestOrigin, origin) {
 				c.Writer.Header().Set("Access-Control-Allow-Origin", requestOrigin)
 			}

--- a/pkg/services/viewservice/listview.go
+++ b/pkg/services/viewservice/listview.go
@@ -57,9 +57,9 @@ func OptionSort(sort string) ViewGeneratorsOption {
 	return optionFunc(func(cfg *viewGeneratorOptions) {
 		cfg.sort = make(map[int]viewGeneratorOptionSort) // Initialize the map
 		for i, item := range strings.Split(sort, ",") {
-			if strings.HasPrefix(item, "-") {
+			if after, ok := strings.CutPrefix(item, "-"); ok {
 				cfg.sort[i] = viewGeneratorOptionSort{
-					name: strings.TrimPrefix(item, "-"),
+					name: after,
 					desc: true,
 				}
 			} else {


### PR DESCRIPTION
Ran `go fix` to replace old practices.

- Replaced interface{} with any
- replaced old for loops `for i := 0; i < controlPlaneNodesLength; i++` with `for i := range controlPlaneNodesLength`
- Removed omitempty on json tags where the value would not do anything (structs without pointers)
- Replaced TypeOf with TypeFor
- Replaced Split with SplitSeq