### PR TITLE
feat(clusters): add force param to cluster purge endpoint

### DIFF
--- a/internal/apiservices/clustersservice/clusters_purge.go
+++ b/internal/apiservices/clustersservice/clusters_purge.go
@@ -53,7 +53,12 @@ type PurgeResult struct {
 //
 // The clusterid required for the v1 resources collection is resolved from the
 // cluster document. ErrClusterNotFound is returned if no cluster matches uid.
-func PurgeClusterByUid(ctx context.Context, uid string) (PurgeResult, error) {
+//
+// force skips the recent-activity safety check. Intended for controlled
+// decommissioning where the caller has already verified the cluster's agents
+// are stopped (e.g. pre-cluster-delete tooling); external reporters may keep
+// refreshing lastobserved long after the cluster itself is being torn down.
+func PurgeClusterByUid(ctx context.Context, uid string, force bool) (PurgeResult, error) {
 	ctx, span := rortracer.StartSpan(ctx, "clustersservice.PurgeClusterByUid")
 	defer span.End()
 
@@ -95,11 +100,19 @@ func PurgeClusterByUid(ctx context.Context, uid string) (PurgeResult, error) {
 		lastReport = lastSeenV2
 	}
 	if !lastReport.IsZero() && time.Since(lastReport) < clusterInactivityThreshold {
-		return result, fmt.Errorf("%w: last reported %s ago (v1: %s, v2: %s)",
-			ErrClusterRecentlyActive,
-			time.Since(lastReport).Round(time.Second),
-			formatReportTime(clusterDoc.LastObserved),
-			formatReportTime(lastSeenV2),
+		if !force {
+			return result, fmt.Errorf("%w: last reported %s ago (v1: %s, v2: %s)",
+				ErrClusterRecentlyActive,
+				time.Since(lastReport).Round(time.Second),
+				formatReportTime(clusterDoc.LastObserved),
+				formatReportTime(lastSeenV2),
+			)
+		}
+		rlog.Warnc(ctx, "force purge: skipping recent-activity check",
+			rlog.String("uid", uid),
+			rlog.String("clusterid", clusterDoc.ClusterId),
+			rlog.String("last report v1", formatReportTime(clusterDoc.LastObserved)),
+			rlog.String("last report v2", formatReportTime(lastSeenV2)),
 		)
 	}
 

--- a/internal/controllers/clusterscontroller/clusters_controller_delete.go
+++ b/internal/controllers/clusterscontroller/clusters_controller_delete.go
@@ -3,6 +3,7 @@ package clusterscontroller
 import (
 	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/NorskHelsenett/ror-api/internal/acl/aclservice"
 	"github.com/NorskHelsenett/ror-api/internal/apiservices/clustersservice"
@@ -26,7 +27,8 @@ import (
 //	@Tags			clusters
 //	@Accept			application/json
 //	@Produce		application/json
-//	@Param			uid	path		string	true	"cluster uid"
+//	@Param			uid		path	string	true	"cluster uid"
+//	@Param			force	query	bool	false	"skip the recent-activity safety check; for controlled decommissioning where the caller has verified the cluster's agents are stopped"
 //	@Success		200	{object}	clustersservice.PurgeResult
 //	@Failure		403	{string}	Forbidden
 //	@Failure		401	{object}	rorerror.ErrorData
@@ -58,7 +60,11 @@ func DeleteClusterByUid() gin.HandlerFunc {
 			return
 		}
 
-		result, err := clustersservice.PurgeClusterByUid(ctx, uid)
+		// force=true skips the recent-activity guard — restricted to callers that
+		// already hold ror global delete access (checked above).
+		force, _ := strconv.ParseBool(c.Query("force"))
+
+		result, err := clustersservice.PurgeClusterByUid(ctx, uid, force)
 		if err != nil {
 			if errors.Is(err, clustersservice.ErrClusterNotFound) {
 				c.JSON(http.StatusNotFound, "404: Cluster not found")


### PR DESCRIPTION
## What

Adds an optional `force` query param to `DELETE /v1/clusters/uid/{uid}`. `?force=true` skips the 10-minute recent-activity guard in `PurgeClusterByUid`. Default behavior (no param) is unchanged.

## Why

The guard treats *any* fresh heartbeat as "cluster is alive" — but heartbeats also come from management-plane reporters outside the guest cluster, which keep refreshing `lastobserved` while a cluster is deliberately being decommissioned. With a ~15 min reporter cadence vs the 10 min threshold, a legitimate purge is blocked for 10–30 minutes waiting for an inactivity window.

Observed in practice while decommissioning 4 clusters (t-slettefest-888/444, d-wh-bgo-001, d-wh-osl-001) with pre-cleanup tooling that scales the ror agents to zero and *verifies the pods are gone* before purging — a stronger liveness check than the timestamp heuristic, yet the API still refused with 409 for up to ~29 minutes.

## Safety

- Access unchanged: the `ror/global` **delete** ACL check runs before the param is read — `force` grants nothing to callers who couldn't already purge.
- A forced purge that skips the guard logs a warning with both report timestamps (v1 `lastobserved`, v2 `agentstatus.lastseen`) for the audit trail.
- No callers break: param is optional; grepped rorctl/ror-web/ror — nothing else uses this endpoint.

## Notes

- `go test ./...` passes.
- Swagger annotation added; committed files under `internal/docs/` are intentionally *not* regenerated here — they are ~5k lines stale repo-wide and CI/release regenerate at build time. Suggest a separate housekeeping PR.
- Follow-up worth discussing: should the guard consider only the in-cluster agent's own report (v2 `lastseen`) rather than external reporters' `lastobserved`? That would fix the semantics for all callers, and `force` would remain the explicit escape hatch.
